### PR TITLE
Add Django Corsheaders package

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
 
     # Third-party apps
     'rest_framework',
+    'corsheaders',
 
     # System apps
     'messenger',
@@ -49,6 +50,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 python = "^3.10"
 django = "^5.0"
 djangorestframework = "^3.14.0"
+django-cors-headers = "^4.3.1"
 
 [tool.poetry.group.test.dependencies]
 pytest-django = "^4.7.0"


### PR DESCRIPTION
- This package allows us to set CORS Allowed origins so our frontend can connect to our API