### PR TITLE
Retrieve Channel Messages Endpoint 

### DIFF
--- a/core/permissions/channel.py
+++ b/core/permissions/channel.py
@@ -1,0 +1,11 @@
+from rest_framework import permissions
+
+from messenger import queries as message_queries
+
+
+class IsChannelMemberPermission(permissions.BasePermission):
+    """Returns True if the user is a member of the channel"""
+
+    def has_permission(self, request, view):
+        channel = view.get_object()
+        return message_queries.is_channel_member(channel=channel, user=request.user)

--- a/messenger/api.py
+++ b/messenger/api.py
@@ -5,6 +5,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 
 from core.permissions.base import IsOwnerPermission
+from core.permissions.channel import IsChannelMemberPermission
 from core.viewsets.mixins import AppModelViewSet
 
 from messenger import queries as messenger_queries
@@ -24,6 +25,11 @@ class ChannelViewSet(AppModelViewSet):
             or self.action == "destroy"
         ):
             return [permission() for permission in [IsAuthenticated, IsOwnerPermission]]
+        elif self.action == "retrieve":
+            return [
+                permission()
+                for permission in [IsAuthenticated, IsChannelMemberPermission]
+            ]
         return super().get_permissions()
 
     def perform_create(self, serializer):

--- a/messenger/api.py
+++ b/messenger/api.py
@@ -81,6 +81,24 @@ class ChannelViewSet(AppModelViewSet):
         serializer = self.get_serializer(channel)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @action(
+        detail=True,
+        methods=["GET"],
+        permission_classes=[IsAuthenticated, IsChannelMemberPermission],
+    )
+    def messages(self, request, pk=None):
+        messages = messenger_queries.get_all_channel_messages(pk)
+        page = self.paginate_queryset(messages)
+        if page is not None:
+            serializer = messenger_serializer.ChannelMessageDisplaySerializer(
+                page, many=True
+            )
+            return self.get_paginated_response(serializer.data)
+        serializer = messenger_serializer.ChannelMessageDisplaySerializer(
+            messages, many=True
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
 
 class UserChannelsView(viewsets.GenericViewSet, mixins.ListModelMixin):
     queryset = ChannelMember.objects.all()

--- a/messenger/models.py
+++ b/messenger/models.py
@@ -63,4 +63,4 @@ class ChannelMessage(CommonInfo):
     message = models.TextField()
 
     def __str__(self):
-        return f"{self.channel.name} - {self.sender.name}"
+        return f"{self.channel.name} - {self.sender.username}"

--- a/messenger/queries.py
+++ b/messenger/queries.py
@@ -41,3 +41,11 @@ def get_all_channels_for_user(
     user: get_user_model(),
 ) -> QuerySet[messenger_models.Channel]:
     return user.channels.all().order_by("id")
+
+
+def get_all_channel_messages(
+    channel_id: int,
+) -> QuerySet[messenger_models.ChannelMessage]:
+    return messenger_models.ChannelMessage.objects.filter(channel=channel_id).order_by(
+        "-id"
+    )

--- a/messenger/serializers.py
+++ b/messenger/serializers.py
@@ -1,5 +1,7 @@
+from django.contrib.auth import get_user_model
 from rest_framework import serializers
-from messenger.models import Channel, ChannelMember
+
+from messenger.models import Channel, ChannelMember, ChannelMessage
 
 
 class ChannelMemberSerializer(serializers.ModelSerializer):
@@ -31,3 +33,26 @@ class ChannelMemberDisplaySerializer(serializers.Serializer):
 
     class Meta:
         model = ChannelMember
+
+
+class SenderDisplaySerializer(serializers.ModelSerializer):
+    class Meta:
+        model = get_user_model()
+        fields = ("id", "first_name", "last_name", "username")
+        read_only_fields = ("id", "first_name", "last_name", "username")
+
+
+class ChannelMessageDisplaySerializer(serializers.ModelSerializer):
+    # Serializes the ChannelMessage model
+    sender = SenderDisplaySerializer()
+
+    class Meta:
+        model = ChannelMessage
+        fields = (
+            "id",
+            "channel",
+            "sender",
+            "message",
+            "created_at",
+        )
+        read_only_fields = ("id",)

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -1,3 +1,4 @@
 from .users.user import User
 from .messenger.channel import Channel
 from .messenger.channel_member import ChannelMember
+from .messenger.channel_message import ChannelMessage

--- a/tests/factories/messenger/channel.py
+++ b/tests/factories/messenger/channel.py
@@ -11,7 +11,7 @@ class Channel(factory.django.DjangoModelFactory):
 
     name = "group-hangout"
     owner = factory.SubFactory(User)
-    invite_code = factory.Sequence(lambda o: f"QWERTYE{o}")
+    invite_code = factory.Sequence(lambda o: f"ABC{o}")
 
     class Meta:
         model = messenger_models.Channel

--- a/tests/factories/messenger/channel_message.py
+++ b/tests/factories/messenger/channel_message.py
@@ -1,0 +1,18 @@
+import factory
+
+from messenger import models as messenger_models
+from tests.factories.messenger.channel import Channel
+from tests.factories.users.user import User
+
+
+class ChannelMessage(factory.django.DjangoModelFactory):
+    """
+    Channel Member Factory
+    """
+
+    message = "Channel Message"
+    sender = factory.SubFactory(User)
+    channel = factory.SubFactory(Channel)
+
+    class Meta:
+        model = messenger_models.ChannelMessage

--- a/tests/integration/messenger/queries/test_get_all_channel_messages.py
+++ b/tests/integration/messenger/queries/test_get_all_channel_messages.py
@@ -1,0 +1,25 @@
+from tests import factories
+
+from messenger import queries as messenger_queries
+
+
+def test_get_channel_by_code():
+    """
+    Given: A channel has only two messages
+    Expect: We can only get the messages for that specific channel
+    """
+
+    # Create the channel we will be testing...
+    channel_a = factories.Channel()
+
+    # ... Also create messages that belongs to that channel...
+    factories.ChannelMessage(channel=channel_a)
+    factories.ChannelMessage(channel=channel_a)
+
+    # ... And a message that does not belong to that channel...
+    factories.ChannelMessage()
+
+    messages = messenger_queries.get_all_channel_messages(channel_a)
+
+    # Assert that we have only gotten two messages...
+    assert messages.count() == 2

--- a/tests/integration/messenger/queries/test_get_all_channels_for_user.py
+++ b/tests/integration/messenger/queries/test_get_all_channels_for_user.py
@@ -25,6 +25,6 @@ def test_get_channel_by_code():
     # Assert that we have 2 channels...
     assert channels.count() == 2
 
-    # And those two channels are the channels that the user is a member of.
-    assert channel_a.pk == channels[0].pk
-    assert channel_b.pk == channels[1].pk
+    # And those two channels are the channels that the user is a member of
+    assert channel_a.pk == channels[0].channel.pk
+    assert channel_b.pk == channels[1].channel.pk


### PR DESCRIPTION
Summary
----

This PR contains an endpoint to list all the messages of a channel. The user must be logged in and must be a member of the channel in order to access the messages.

Included in this PR
- [x] endpoint
- [x] testcases